### PR TITLE
Anonymous functions that call named functions

### DIFF
--- a/test.js
+++ b/test.js
@@ -5,3 +5,21 @@ var fnName = require('./');
 it('should return the name of named functions', function () {
 	assert.equal(fnName(function foo() {}), 'foo');
 });
+
+it('anonymous', function () {
+	assert.equal(fnName(function () {}), null);
+});
+
+it('nested', function () {
+	assert.equal(fnName(function () {
+		function nested() {}
+	}), null);
+});
+
+it('nested callback', function () {
+	function call (fn) { fn() }
+
+	assert.equal(fnName(function () {
+		call(function callback () {});
+	}), null);
+});


### PR DESCRIPTION
I was surprised to see this issue when I was using ava. 
Is it correct behavior?

```js
fnName(function () { function nested() {} })
//=> 'nested'

function call (fn) { fn() }
fnName(function () {
  call(function callback() {});
});
//=> 'callback'
```

I added test examples to this PR.